### PR TITLE
fix: add missing WCAG IDs and keyboard shortcut toast

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -317,12 +317,13 @@ export default function GeneratorPage() {
           document.body.appendChild(link);
           link.click();
           document.body.removeChild(link);
+          showToast("QR Code downloaded successfully!", "success");
         }
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [qrDataUrl, exportFormat]);
+  }, [qrDataUrl, exportFormat, showToast]);
 
   // Icon components
   const Icon = ({
@@ -815,6 +816,7 @@ export default function GeneratorPage() {
 
                   {/* Contrast Alert */}
                   <div
+                    id="contrastAlert"
                     className={`mt-4 flex items-start gap-3 rounded-md border p-3 ${
                       wcagAAA
                         ? "border-[var(--pro-success)] bg-[var(--pro-success-light)]"
@@ -856,6 +858,7 @@ export default function GeneratorPage() {
                       </div>
                       <div className="mt-2 flex gap-1.5">
                         <span
+                          id="wcagAA"
                           className={`rounded bg-white px-2 py-0.5 text-[10px] font-bold ${
                             wcagAA
                               ? "text-[var(--pro-success)]"
@@ -865,6 +868,7 @@ export default function GeneratorPage() {
                           AA {wcagAA ? "✓" : "✗"}
                         </span>
                         <span
+                          id="wcagAAA"
                           className={`rounded bg-white px-2 py-0.5 text-[10px] font-bold ${
                             wcagAAA
                               ? "text-[var(--pro-success)]"


### PR DESCRIPTION
## Summary
- Add `id="contrastAlert"` to contrast alert container element
- Add `id="wcagAA"` and `id="wcagAAA"` to WCAG compliance badges
- Add toast notification for Cmd/Ctrl+D keyboard shortcut download (matches download button behavior)
- Fix React useEffect dependency array to include `showToast`

## Bugs Fixed
- **Bug #1**: Missing element IDs for WCAG badges (prevents automated accessibility testing)
- **Bug #3**: Keyboard shortcut download missing toast notification

## Test Plan
- [ ] Verify `document.getElementById('wcagAA')` returns element
- [ ] Verify `document.getElementById('wcagAAA')` returns element  
- [ ] Verify `document.getElementById('contrastAlert')` returns element
- [ ] Verify Cmd/Ctrl+D shows toast "QR Code downloaded successfully!"
- [ ] Verify no duplicate IDs in page

🤖 Generated with [Claude Code](https://claude.com/claude-code)