### PR TITLE
fix: Remove toast when content type changed

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -664,7 +664,6 @@ function GeneratorContent() {
     if (template) {
       setUrl(template.template);
       validateURL(template.template);
-      showToast(`Template loaded: ${template.label}`, "success");
     }
   };
 


### PR DESCRIPTION
## Summary
- Removes the toast notification that appears when switching content types (URL → WiFi → Email → etc)
- User doesn't need confirmation for this routine action
- Reduces notification noise and improves UX

## Test Plan
- [x] Switch between all content types (Website, WiFi, Contact, Email, SMS, Location)
- [x] Verify no toasts appear on content type change
- [x] Verify content type switching still works correctly
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)