### PR TITLE
fix: Remove toast notifications when changing content type

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -664,7 +664,7 @@ function GeneratorContent() {
     if (template) {
       setUrl(template.template);
       validateURL(template.template);
-      showToast(`Template loaded: ${template.label}`, "success");
+      // Removed toast notification for content type changes - user requested silent switching
     }
   };
 


### PR DESCRIPTION
## Summary
- Removes toast notification that appeared when user changes content type (URL, WiFi, Email, SMS, etc.)
- Content type switching is now silent as requested
- All other toasts (download success, copy, errors) remain intact

## Test plan
- [ ] Change from URL to WiFi → no toast
- [ ] Change to Email → no toast  
- [ ] Change to SMS → no toast
- [ ] Change to Contact → no toast
- [ ] Change to Location → no toast
- [ ] Download QR code → toast still appears ✓
- [ ] Copy to clipboard → toast still appears ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)