### PR TITLE
fix: Remove template loaded toast notification

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -664,7 +664,6 @@ function GeneratorContent() {
     if (template) {
       setUrl(template.template);
       validateURL(template.template);
-      showToast(`Template loaded: ${template.label}`, "success");
     }
   };
 


### PR DESCRIPTION
## Summary
- Remove the annoying "Template loaded: {label}" toast notification that appears when clicking content type buttons (URL/Text/Email/Phone/etc)
- Template loading functionality (setUrl, validateURL) remains intact

## Test plan
- [ ] Go to /generator
- [ ] Click different content type buttons (URL, Text, Email, Phone)
- [ ] Verify NO toasts appear
- [ ] Verify templates still work (URL changes correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)