### PR TITLE
Fix 4 UI bugs - back button, skip link, styling, orange border

### DIFF
--- a/src/app/bulk/page.tsx
+++ b/src/app/bulk/page.tsx
@@ -20,14 +20,6 @@ export const metadata: Metadata = {
 export default function BulkPage() {
   return (
     <>
-      {/* Skip to main content link for accessibility */}
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[100] focus:bg-accent focus:px-4 focus:py-2 focus:text-white"
-      >
-        Skip to main content
-      </a>
-
       {/* Navigation */}
       <header>
         <nav
@@ -46,7 +38,7 @@ export default function BulkPage() {
             </Link>
 
             {/* Navigation Links */}
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-6">
               <Link
                 href="/generator"
                 className="text-sm font-medium text-muted transition-colors hover:text-fg"
@@ -55,7 +47,7 @@ export default function BulkPage() {
               </Link>
               <Link
                 href="/bulk"
-                className="bg-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-fg"
+                className="text-sm font-medium text-fg transition-colors hover:text-accent"
               >
                 Bulk Creation
               </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,16 +23,16 @@ export default function Home() {
             </Link>
 
             {/* Navigation Links */}
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-6">
               <Link
                 href="/generator"
-                className="hidden text-sm font-medium text-muted transition-colors hover:text-fg sm:block"
+                className="text-sm font-medium text-muted transition-colors hover:text-fg"
               >
                 Advanced Generator
               </Link>
               <Link
                 href="/bulk"
-                className="bg-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-fg"
+                className="text-sm font-medium text-muted transition-colors hover:text-fg"
               >
                 Bulk Creation
               </Link>

--- a/src/components/BulkQRCreator.tsx
+++ b/src/components/BulkQRCreator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Papa from "papaparse";
 import * as XLSX from "xlsx";
 import QRCode from "qrcode";
@@ -130,6 +131,8 @@ const DEFAULT_DOWNLOAD: DownloadSettings = {
 };
 
 export default function BulkQRCreator() {
+  const router = useRouter();
+
   // Wizard state
   const [currentStep, setCurrentStep] = useState<WizardStep>(1);
   const [completedSteps, setCompletedSteps] = useState<Set<WizardStep>>(
@@ -1220,7 +1223,10 @@ export default function BulkQRCreator() {
   };
 
   const handlePrevious = () => {
-    if (currentStep > 1) {
+    if (currentStep === 1) {
+      // Navigate back to home when on step 1
+      router.push("/");
+    } else {
       setCurrentStep((currentStep - 1) as WizardStep);
     }
   };
@@ -2581,8 +2587,7 @@ export default function BulkQRCreator() {
             <div className="mt-10 flex items-center justify-between border-t border-border pt-6">
               <button
                 onClick={currentStep === 5 ? resetWizard : handlePrevious}
-                disabled={currentStep === 1 && !file}
-                className="flex items-center gap-2 border border-border bg-white px-5 py-3 font-medium transition-colors hover:border-fg disabled:opacity-50"
+                className="flex items-center gap-2 border border-border bg-white px-5 py-3 font-medium transition-colors hover:border-fg"
               >
                 {currentStep === 5 ? (
                   <>
@@ -2608,7 +2613,7 @@ export default function BulkQRCreator() {
                     >
                       <path d="M19 12H5M12 19l-7-7 7-7" />
                     </svg>
-                    Back
+                    {currentStep === 1 ? "Home" : "Back"}
                   </>
                 )}
               </button>

--- a/src/components/ComparisonSection.tsx
+++ b/src/components/ComparisonSection.tsx
@@ -124,7 +124,7 @@ export default function ComparisonSection() {
                     key={competitor.name}
                     className={`border-b border-border px-5 py-4 text-left font-serif text-lg font-normal ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-t-[3px] border-accent bg-accent text-white"
+                        ? "border-l-[3px] border-r-[3px] border-t-[3px] border-fg bg-accent text-white"
                         : "bg-surface"
                     } ${index === 0 ? "" : ""}`}
                   >
@@ -151,7 +151,7 @@ export default function ComparisonSection() {
                     key={`pricing-${competitor.name}`}
                     className={`border-b border-border px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -176,7 +176,7 @@ export default function ComparisonSection() {
                     key={`expiration-${competitor.name}`}
                     className={`border-b border-border px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -199,7 +199,7 @@ export default function ComparisonSection() {
                     key={`resolution-${competitor.name}`}
                     className={`border-b border-border px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -222,7 +222,7 @@ export default function ComparisonSection() {
                     key={`formats-${competitor.name}`}
                     className={`border-b border-border px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -245,7 +245,7 @@ export default function ComparisonSection() {
                     key={`scans-${competitor.name}`}
                     className={`border-b border-border px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -268,7 +268,7 @@ export default function ComparisonSection() {
                     key={`design-${competitor.name}`}
                     className={`px-5 py-4 ${
                       competitor.isHighlighted
-                        ? "border-b-[3px] border-l-[3px] border-r-[3px] border-accent bg-accent-light"
+                        ? "border-b-[3px] border-l-[3px] border-r-[3px] border-fg bg-accent-light"
                         : ""
                     }`}
                   >
@@ -295,7 +295,7 @@ export default function ComparisonSection() {
               key={`card-${competitor.name}`}
               className={`rounded-lg border-2 p-6 ${
                 competitor.isHighlighted
-                  ? "border-accent bg-accent-light"
+                  ? "border-fg bg-accent-light"
                   : "border-border bg-bg"
               }`}
             >


### PR DESCRIPTION
## Summary
- Fix back button on `/bulk` page to navigate to home when on step 1
- Remove "Skip to Main Content" accessibility link from bulk page
- Make navigation link styling consistent (both Advanced Generator and Bulk Creation use same text link styling)
- Remove orange border from comparison table (changed from accent to fg color)

## Test plan
- [ ] Verify back button on `/bulk` page navigates to home when on step 1
- [ ] Verify "Skip to Main Content" is no longer visible
- [ ] Verify navigation links have consistent styling on both homepage and bulk page
- [ ] Verify comparison table no longer has orange border highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)