### PR TITLE
Fix 3 auth UX issues

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -120,10 +120,18 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
 
           <button
             type="submit"
-            disabled={loading}
-            className="w-full bg-accent px-6 py-4 text-[15px] font-semibold text-white transition-colors hover:bg-fg disabled:opacity-50"
+            disabled={loading || message?.type === 'success'}
+            className={`w-full px-6 py-4 text-[15px] font-semibold transition-colors disabled:cursor-not-allowed ${
+              message?.type === 'success'
+                ? 'bg-green-600 text-white'
+                : 'bg-accent text-white hover:bg-fg disabled:opacity-50'
+            }`}
           >
-            {loading ? 'Sending...' : 'Send Magic Link'}
+            {loading
+              ? 'Sending...'
+              : message?.type === 'success'
+                ? 'Magic Link Sent ✓'
+                : 'Send Magic Link'}
           </button>
         </form>
 


### PR DESCRIPTION
## Summary
- **Button state fix**: Disable "Send Magic Link" button after email is sent and show success state with green color and checkmark
- **Email template**: Updated Supabase magic link email subject to "Sign in to The QR Spot"
- **Email content**: Updated email body with branded messaging

## Changes
- `src/components/AuthModal.tsx`: Button now disabled when `message.type === 'success'`, shows "Magic Link Sent ✓" with green background
- Supabase Auth config: Updated `mailer_subjects_magic_link` and `mailer_templates_magic_link_content` via Management API

## Test plan
- [ ] Build passes locally
- [ ] Button disables after successful email send
- [ ] Button shows green color and checkmark text
- [ ] Email subject shows "Sign in to The QR Spot"
- [ ] Email content shows branded messaging

## Note on Email Sender
The email sender name can only be changed with custom SMTP configuration. Currently using Supabase's default sender. This is expected behavior without custom SMTP setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)