### PR TITLE
fix: Mobile UX and paywall improvements

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -719,7 +719,7 @@ function GeneratorContent() {
     };
   };
 
-  // URL validation
+  // URL/Content validation - supports URLs and special QR content types
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const validateURL = useCallback(
     debounce((value: string) => {
@@ -727,11 +727,42 @@ function GeneratorContent() {
         setUrlValid(false);
         return;
       }
+
+      const trimmedValue = value.trim();
+
+      // Check for special QR content types that are valid but not URLs
+      const specialProtocols = [
+        "WIFI:", // WiFi network config
+        "wifi:", // WiFi network config (lowercase)
+        "BEGIN:VCARD", // vCard contact
+        "BEGIN:VCALENDAR", // Calendar event
+        "sms:", // SMS message
+        "tel:", // Phone number
+        "mailto:", // Email
+        "geo:", // Geographic location
+      ];
+
+      const isSpecialContent = specialProtocols.some((protocol) =>
+        trimmedValue.startsWith(protocol)
+      );
+
+      if (isSpecialContent) {
+        setUrlValid(true);
+        return;
+      }
+
+      // For regular URLs, validate normally
       try {
-        new URL(value);
+        new URL(trimmedValue);
         setUrlValid(true);
       } catch {
-        setUrlValid(false);
+        // If it doesn't have a protocol, try adding https://
+        try {
+          new URL("https://" + trimmedValue);
+          setUrlValid(true);
+        } catch {
+          setUrlValid(false);
+        }
       }
     }, 300),
     []

--- a/src/components/SimpleQRGenerator.tsx
+++ b/src/components/SimpleQRGenerator.tsx
@@ -368,18 +368,18 @@ export default function SimpleQRGenerator() {
 
       {/* Actions Section */}
       {qrDataUrl && (
-        <div className="flex flex-col gap-4">
-          <div className="flex items-center gap-4">
+        <div className="flex flex-col gap-3 sm:gap-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             <button
               onClick={downloadPNG}
-              className="flex flex-1 items-center justify-center gap-2 bg-fg px-6 py-4 text-[15px] font-semibold text-bg transition-colors hover:bg-accent"
+              className="flex flex-1 items-center justify-center gap-1.5 bg-fg px-3 py-2.5 text-sm font-semibold text-bg transition-colors hover:bg-accent sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
             >
               <svg
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
                 strokeWidth="2"
-                className="h-[18px] w-[18px]"
+                className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
               >
                 <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
               </svg>
@@ -388,14 +388,14 @@ export default function SimpleQRGenerator() {
             {savedQrId ? (
               <Link
                 href="/dashboard"
-                className="flex flex-1 items-center justify-center gap-2 border-2 border-green-600 bg-green-50 px-6 py-4 text-[15px] font-semibold text-green-700 transition-colors hover:bg-green-100"
+                className="flex flex-1 items-center justify-center gap-1.5 border-2 border-green-600 bg-green-50 px-3 py-2.5 text-sm font-semibold text-green-700 transition-colors hover:bg-green-100 sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
               >
                 <svg
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
-                  className="h-[18px] w-[18px]"
+                  className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
                 >
                   <path d="M20 6L9 17l-5-5" />
                 </svg>
@@ -405,14 +405,14 @@ export default function SimpleQRGenerator() {
               <button
                 onClick={saveQRCode}
                 disabled={isSaving}
-                className="flex flex-1 items-center justify-center gap-2 border-2 border-fg bg-transparent px-6 py-4 text-[15px] font-semibold text-fg transition-colors hover:bg-fg hover:text-bg disabled:cursor-not-allowed disabled:opacity-50"
+                className="flex flex-1 items-center justify-center gap-1.5 border-2 border-fg bg-transparent px-3 py-2.5 text-sm font-semibold text-fg transition-colors hover:bg-fg hover:text-bg disabled:cursor-not-allowed disabled:opacity-50 sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
               >
                 <svg
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
-                  className="h-[18px] w-[18px]"
+                  className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
                 >
                   <path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z" />
                   <polyline points="17 21 17 13 7 13 7 21" />

--- a/src/components/dashboard/EditModal.tsx
+++ b/src/components/dashboard/EditModal.tsx
@@ -898,7 +898,179 @@ export default function EditModal({
     </div>
   );
 
-  // Analytics Tab
+  // Analytics Tab - Locked State (for free users)
+  const renderLockedAnalytics = () => (
+    <div className="p-6">
+      {/* QR Info Row */}
+      <div className="mb-6 flex items-center gap-4 rounded-xl bg-[var(--surface)] p-4">
+        <div className="flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-lg border border-[var(--border)] bg-white">
+          {qrPreview ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={qrPreview} alt="QR preview" className="h-11 w-11" />
+          ) : (
+            <div className="h-11 w-11 animate-pulse rounded bg-[var(--border)]" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-semibold text-[var(--fg)]">{qrCode.title}</div>
+          <div className="truncate text-xs text-[var(--muted)]">
+            theqrspot.com/r/{qrCode.short_code}
+          </div>
+        </div>
+      </div>
+
+      {/* Lock Message */}
+      <div className="mb-6 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--surface)] p-8 text-center">
+        <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-[var(--accent-light)]">
+          <svg
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            className="h-8 w-8 text-[var(--accent)]"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+            />
+          </svg>
+        </div>
+        <h3 className="mb-2 font-serif text-xl text-[var(--fg)]">
+          Analytics Locked
+        </h3>
+        <p className="mb-4 text-sm text-[var(--muted)]">
+          Unlock to view detailed scan analytics including total scans, weekly
+          trends, and more
+        </p>
+      </div>
+
+      {/* Pricing Options */}
+      <div className="mb-6 grid grid-cols-2 gap-3">
+        {/* Single QR Option */}
+        <button
+          onClick={() => setSelectedPlan("single")}
+          className={`relative rounded-xl border-2 p-4 text-left transition-all ${
+            selectedPlan === "single"
+              ? "border-[var(--accent)] bg-[var(--accent-light)]"
+              : "border-[var(--border)] bg-white hover:border-[var(--accent)]"
+          }`}
+        >
+          {selectedPlan === "single" && (
+            <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--accent)]">
+              <svg
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                className="h-3 w-3 text-white"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={3}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+          )}
+          <div className="font-serif text-2xl text-[var(--fg)]">$3.99</div>
+          <div className="mt-1 text-xs font-semibold text-[var(--fg)]">
+            This QR Only
+          </div>
+          <div className="mt-1 text-[10px] text-[var(--muted)]">
+            Unlock analytics for this QR
+          </div>
+        </button>
+
+        {/* Unlimited Option */}
+        <button
+          onClick={() => setSelectedPlan("unlimited")}
+          className={`relative rounded-xl border-2 p-4 text-left transition-all ${
+            selectedPlan === "unlimited"
+              ? "border-[var(--accent)] bg-[var(--accent-light)]"
+              : "border-[var(--border)] bg-white hover:border-[var(--accent)]"
+          }`}
+        >
+          <div className="absolute -top-2 left-3 rounded bg-[var(--accent)] px-1.5 py-0.5 text-[9px] font-bold uppercase text-white">
+            Best Value
+          </div>
+          {selectedPlan === "unlimited" && (
+            <div className="absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--accent)]">
+              <svg
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                className="h-3 w-3 text-white"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={3}
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </div>
+          )}
+          <div className="font-serif text-2xl text-[var(--fg)]">$9.99</div>
+          <div className="mt-1 text-xs font-semibold text-[var(--fg)]">
+            Unlimited QRs
+          </div>
+          <div className="mt-1 text-[10px] text-[var(--muted)]">
+            Analytics for all QR codes
+          </div>
+        </button>
+      </div>
+
+      {error && <p className="mb-4 text-center text-sm text-red-500">{error}</p>}
+
+      {/* Unlock Button */}
+      <button
+        onClick={() => handleUpgrade()}
+        disabled={processingPayment}
+        className="flex w-full items-center justify-center gap-2 rounded-xl bg-[var(--accent)] px-6 py-4 text-base font-semibold text-white transition-all hover:-translate-y-0.5 hover:bg-[#e64500] hover:shadow-lg disabled:translate-y-0 disabled:opacity-70"
+      >
+        {processingPayment ? (
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+        ) : (
+          <>
+            <svg
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              className="h-5 w-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+              />
+            </svg>
+            Unlock for {selectedPlan === "unlimited" ? "$9.99" : "$3.99"}
+          </>
+        )}
+      </button>
+
+      <div className="mt-4 flex items-center justify-center gap-2 text-xs text-[var(--muted)]">
+        <svg
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          className="h-3.5 w-3.5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+          />
+        </svg>
+        Secure payment via Stripe
+      </div>
+    </div>
+  );
+
+  // Analytics Tab - Unlocked State (for paid users)
   const renderAnalyticsTab = () => (
     <div className="p-6">
       {/* Coming Soon / Basic Stats */}
@@ -966,7 +1138,14 @@ export default function EditModal({
       case "format":
         return renderFormatTab();
       case "analytics":
-        return renderAnalyticsTab();
+        if (loadingProfile) {
+          return (
+            <div className="flex h-64 items-center justify-center">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--border)] border-t-[var(--accent)]" />
+            </div>
+          );
+        }
+        return canEditContent ? renderAnalyticsTab() : renderLockedAnalytics();
       default:
         return null;
     }


### PR DESCRIPTION
## Summary
- Reduced button size on mobile in SimpleQRGenerator (responsive padding using sm: breakpoint)
- Added paywall check for Analytics tab in EditModal (free users now see locked state with upgrade options)
- Fixed content type validation in advanced generator to properly accept WIFI, vCard, SMS, tel, mailto, and geo content types

## Changes

### 1. Mobile Button Sizing (SimpleQRGenerator.tsx)
- Added responsive padding classes: `px-3 py-2.5 sm:px-6 sm:py-4`
- Reduced font size on mobile: `text-sm sm:text-[15px]`
- Smaller icon sizes on mobile: `h-4 w-4 sm:h-[18px] sm:w-[18px]`
- Tighter gap spacing: `gap-1.5 sm:gap-2`

### 2. Analytics Paywall (EditModal.tsx)
- Added `renderLockedAnalytics()` function for free users
- Modified `renderTabContent()` to check `canEditContent` for Analytics tab
- Free users see a paywall UI matching the Content tab design

### 3. Advanced Mode Content Types (generator/page.tsx)
- Updated `validateURL` to recognize special QR content types:
  - WIFI: / wifi:
  - BEGIN:VCARD / BEGIN:VCALENDAR
  - sms: / tel: / mailto: / geo:
- These now properly validate as valid content

## Test Plan
- [ ] Test mobile viewport - buttons should be smaller
- [ ] Test Analytics tab with free user - should show paywall
- [ ] Test Analytics tab with paid user - should show analytics
- [ ] Test quick actions in advanced generator (WiFi, vCard, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)