### PR TITLE
fix: Improve pricing display clarity on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,13 +58,11 @@ export default function Home() {
               id="hero-heading"
               className="font-serif text-4xl leading-[1.1] tracking-tight text-fg md:text-5xl lg:text-6xl"
             >
-              Create unlimited QR codes{" "}
-              <span className="italic text-accent">free</span>.
-              <br />
-              <span className="text-accent">$1.99 to unlock editing.</span>
+              Create QR codes <span className="italic text-accent">free</span>.{" "}
+              <span className="text-accent">$1.99 to edit.</span>
             </h1>
             <p className="mx-auto mt-4 max-w-2xl text-lg text-muted">
-              No subscriptions. Pay once per QR code to unlock editing and analytics.
+              No subscriptions.
             </p>
           </header>
 
@@ -127,11 +125,12 @@ export default function Home() {
               >
                 Professional QR codes.
                 <br />
-                <span className="italic text-accent">Free to create.</span> $1.99
-                to edit.
+                <span className="italic text-accent">Free to create.</span>{" "}
+                $1.99 to edit.
               </h2>
               <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-white/60">
-                Create unlimited QR codes free. Pay $1.99 per QR to unlock editing and analytics.
+                Create unlimited QR codes free. Pay $1.99 per QR to unlock
+                editing and analytics.
               </p>
             </header>
 
@@ -162,7 +161,12 @@ export default function Home() {
                       <rect x="13" y="25" width="2" height="2" />
                       <rect x="9" y="29" width="2" height="2" />
                       {/* Expanding arrows */}
-                      <path d="M18 14 L22 14 L22 10 M22 14 L22 18 L26 18" stroke="currentColor" strokeWidth="1.5" fill="none" />
+                      <path
+                        d="M18 14 L22 14 L22 10 M22 14 L22 18 L26 18"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                      />
                     </svg>
                   </div>
                   <h3 className="font-serif text-2xl tracking-tight">
@@ -171,7 +175,8 @@ export default function Home() {
                 </div>
                 <p className="text-base leading-relaxed text-white/60">
                   Export from 512px up to 4096px. Perfect for billboards,
-                  posters, and large format printing. Print-ready quality at any size.
+                  posters, and large format printing. Print-ready quality at any
+                  size.
                 </p>
               </li>
 
@@ -236,13 +241,55 @@ export default function Home() {
                       <rect x="8" y="20" width="1.5" height="1.5" />
                       <rect x="12" y="20" width="1.5" height="1.5" />
                       {/* Print measurement lines */}
-                      <line x1="26" y1="8" x2="30" y2="8" stroke="currentColor" strokeWidth="1.5" />
-                      <line x1="26" y1="24" x2="30" y2="24" stroke="currentColor" strokeWidth="1.5" />
-                      <line x1="28" y1="8" x2="28" y2="24" stroke="currentColor" strokeWidth="1.5" />
+                      <line
+                        x1="26"
+                        y1="8"
+                        x2="30"
+                        y2="8"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
+                      <line
+                        x1="26"
+                        y1="24"
+                        x2="30"
+                        y2="24"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
+                      <line
+                        x1="28"
+                        y1="8"
+                        x2="28"
+                        y2="24"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
                       {/* Tick marks */}
-                      <line x1="27" y1="12" x2="29" y2="12" stroke="currentColor" strokeWidth="1" />
-                      <line x1="27" y1="16" x2="29" y2="16" stroke="currentColor" strokeWidth="1" />
-                      <line x1="27" y1="20" x2="29" y2="20" stroke="currentColor" strokeWidth="1" />
+                      <line
+                        x1="27"
+                        y1="12"
+                        x2="29"
+                        y2="12"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                      <line
+                        x1="27"
+                        y1="16"
+                        x2="29"
+                        y2="16"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                      <line
+                        x1="27"
+                        y1="20"
+                        x2="29"
+                        y2="20"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
                     </svg>
                   </div>
                   <h3 className="font-serif text-2xl tracking-tight">
@@ -251,7 +298,8 @@ export default function Home() {
                 </div>
                 <p className="text-base leading-relaxed text-white/60">
                   Set DPI from 72 to 600 with a built-in size calculator. Know
-                  exactly how your QR will print. Professional output every time.
+                  exactly how your QR will print. Professional output every
+                  time.
                 </p>
               </li>
 
@@ -265,15 +313,50 @@ export default function Home() {
                     >
                       {/* QR code with gradient/style variation */}
                       <defs>
-                        <linearGradient id="qr-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                          <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
-                          <stop offset="100%" stopColor="currentColor" stopOpacity="0.4" />
+                        <linearGradient
+                          id="qr-gradient"
+                          x1="0%"
+                          y1="0%"
+                          x2="100%"
+                          y2="100%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="1"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                            stopOpacity="0.4"
+                          />
                         </linearGradient>
                       </defs>
                       {/* Corner blocks with rounded edges */}
-                      <rect x="2" y="2" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
-                      <rect x="2" y="25" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
-                      <rect x="25" y="2" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
+                      <rect
+                        x="2"
+                        y="2"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
+                      <rect
+                        x="2"
+                        y="25"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
+                      <rect
+                        x="25"
+                        y="2"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
                       {/* Styled data modules */}
                       <circle cx="10" cy="3" r="1" opacity="0.8" />
                       <circle cx="14" cy="3" r="1" opacity="0.6" />
@@ -341,9 +424,7 @@ export default function Home() {
             <div className="font-serif text-2xl italic text-fg">
               The QR <span className="text-accent">Spot</span>
             </div>
-            <p className="mt-1 text-xs text-muted">
-              Pay once, own forever.
-            </p>
+            <p className="mt-1 text-xs text-muted">Pay once, own forever.</p>
           </div>
 
           {/* Links */}

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import Link from "next/link";
 
 const freePlanFeatures: { text: string; included: boolean }[] = [
   { text: "Create unlimited QR codes", included: true },
   { text: "High resolution export (PNG, SVG, PDF, EPS)", included: true },
   { text: "Customize colors and styles", included: true },
   { text: "Multiple format support", included: true },
+  { text: "Change where the QR points to", included: false },
+  { text: "View scan analytics", included: false },
 ];
 
 const paidFeatures: string[] = [
@@ -15,42 +17,6 @@ const paidFeatures: string[] = [
 ];
 
 export default function PricingSection() {
-  const [loading, setLoading] = useState(false);
-
-  const handlePurchase = async () => {
-    const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_SINGLE || "";
-
-    if (!priceId) {
-      console.error("Price ID is not configured");
-      return;
-    }
-
-    setLoading(true);
-
-    try {
-      const response = await fetch("/api/checkout", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ priceId }),
-      });
-
-      const data = await response.json();
-
-      if (data.url) {
-        // Redirect to Stripe Checkout
-        window.location.href = data.url;
-      } else {
-        console.error("Failed to create checkout session:", data.error);
-        setLoading(false);
-      }
-    } catch (error) {
-      console.error("Checkout error:", error);
-      setLoading(false);
-    }
-  };
-
   return (
     <section
       id="pricing"
@@ -71,7 +37,8 @@ export default function PricingSection() {
             <span className="italic text-accent">No Subscriptions.</span>
           </h2>
           <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-muted">
-            Create unlimited QR codes for free. $1.99 to unlock editing and analytics per QR code.
+            Create unlimited QR codes for free. $1.99 to unlock editing and
+            analytics per QR code.
           </p>
         </header>
 
@@ -106,27 +73,47 @@ export default function PricingSection() {
             <ul className="mt-6 space-y-3" role="list">
               {freePlanFeatures.map((feature, index) => (
                 <li key={index} className="flex items-start gap-3">
-                  <svg
-                    className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-500"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
+                  {feature.included ? (
+                    <svg
+                      className="mt-0.5 h-5 w-5 flex-shrink-0 text-emerald-500"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  ) : (
+                    <svg
+                      className="mt-0.5 h-5 w-5 flex-shrink-0 text-muted"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                      />
+                    </svg>
+                  )}
+                  <span
+                    className={`text-sm ${feature.included ? "text-fg" : "text-muted"}`}
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M5 13l4 4L19 7"
-                    />
-                  </svg>
-                  <span className="text-sm text-fg">{feature.text}</span>
+                    {feature.text}
+                  </span>
                 </li>
               ))}
             </ul>
           </div>
 
           {/* $1.99 Unlock Card */}
-          <div className="relative overflow-hidden rounded-2xl border-2 border-accent bg-bg p-8 shadow-lg shadow-accent/10">
+          <div className="shadow-accent/10 relative overflow-hidden rounded-2xl border-2 border-accent bg-bg p-8 shadow-lg">
             {/* Price Badge */}
             <div className="mb-4">
               <span className="font-serif text-5xl text-fg">$1.99</span>
@@ -163,39 +150,13 @@ export default function PricingSection() {
             </ul>
 
             {/* CTA Button */}
-            <button
-              onClick={handlePurchase}
-              disabled={loading}
-              className="mt-8 w-full rounded-lg bg-accent py-4 text-center font-semibold text-white transition-all duration-200 hover:bg-fg disabled:bg-accent/50"
-              aria-label="Unlock editing and analytics for $1.99"
+            <Link
+              href="/generator"
+              className="mt-8 block w-full rounded-lg bg-accent py-4 text-center font-semibold text-white transition-all duration-200 hover:bg-fg"
+              aria-label="Create a QR code to unlock editing and analytics"
             >
-              {loading ? (
-                <span className="inline-flex items-center gap-2">
-                  <svg
-                    className="h-5 w-5 animate-spin"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                  >
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Processing...
-                </span>
-              ) : (
-                "Unlock for $1.99"
-              )}
-            </button>
+              Get Started
+            </Link>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Add locked features with lock icon (🔒) to FREE tier showing what requires payment: "Change where the QR points to" and "View scan analytics"
- Simplify hero copy from verbose 3-line text to concise: "Create QR codes free. $1.99 to edit. No subscriptions."
- Replace confusing "Unlock for $1.99" button (no QR to unlock on homepage) with "Get Started" linking to the QR generator

## Test plan
- [ ] Verify FREE tier card shows 4 checkmark items + 2 lock icon items
- [ ] Verify hero text is concise (2 lines max)
- [ ] Verify pricing card button says "Get Started" and links to /generator
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)