### PR TITLE
fix(#98): Add Terms of Service page and fix footer links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -64,7 +64,8 @@ export default function Home() {
               <span className="text-accent">$1.99 to unlock editing.</span>
             </h1>
             <p className="mx-auto mt-4 max-w-2xl text-lg text-muted">
-              No subscriptions. Pay once per QR code to unlock editing and analytics.
+              No subscriptions. Pay once per QR code to unlock editing and
+              analytics.
             </p>
           </header>
 
@@ -127,11 +128,12 @@ export default function Home() {
               >
                 Professional QR codes.
                 <br />
-                <span className="italic text-accent">Free to create.</span> $1.99
-                to edit.
+                <span className="italic text-accent">Free to create.</span>{" "}
+                $1.99 to edit.
               </h2>
               <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-white/60">
-                Create unlimited QR codes free. Pay $1.99 per QR to unlock editing and analytics.
+                Create unlimited QR codes free. Pay $1.99 per QR to unlock
+                editing and analytics.
               </p>
             </header>
 
@@ -162,7 +164,12 @@ export default function Home() {
                       <rect x="13" y="25" width="2" height="2" />
                       <rect x="9" y="29" width="2" height="2" />
                       {/* Expanding arrows */}
-                      <path d="M18 14 L22 14 L22 10 M22 14 L22 18 L26 18" stroke="currentColor" strokeWidth="1.5" fill="none" />
+                      <path
+                        d="M18 14 L22 14 L22 10 M22 14 L22 18 L26 18"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        fill="none"
+                      />
                     </svg>
                   </div>
                   <h3 className="font-serif text-2xl tracking-tight">
@@ -171,7 +178,8 @@ export default function Home() {
                 </div>
                 <p className="text-base leading-relaxed text-white/60">
                   Export from 512px up to 4096px. Perfect for billboards,
-                  posters, and large format printing. Print-ready quality at any size.
+                  posters, and large format printing. Print-ready quality at any
+                  size.
                 </p>
               </li>
 
@@ -236,13 +244,55 @@ export default function Home() {
                       <rect x="8" y="20" width="1.5" height="1.5" />
                       <rect x="12" y="20" width="1.5" height="1.5" />
                       {/* Print measurement lines */}
-                      <line x1="26" y1="8" x2="30" y2="8" stroke="currentColor" strokeWidth="1.5" />
-                      <line x1="26" y1="24" x2="30" y2="24" stroke="currentColor" strokeWidth="1.5" />
-                      <line x1="28" y1="8" x2="28" y2="24" stroke="currentColor" strokeWidth="1.5" />
+                      <line
+                        x1="26"
+                        y1="8"
+                        x2="30"
+                        y2="8"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
+                      <line
+                        x1="26"
+                        y1="24"
+                        x2="30"
+                        y2="24"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
+                      <line
+                        x1="28"
+                        y1="8"
+                        x2="28"
+                        y2="24"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                      />
                       {/* Tick marks */}
-                      <line x1="27" y1="12" x2="29" y2="12" stroke="currentColor" strokeWidth="1" />
-                      <line x1="27" y1="16" x2="29" y2="16" stroke="currentColor" strokeWidth="1" />
-                      <line x1="27" y1="20" x2="29" y2="20" stroke="currentColor" strokeWidth="1" />
+                      <line
+                        x1="27"
+                        y1="12"
+                        x2="29"
+                        y2="12"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                      <line
+                        x1="27"
+                        y1="16"
+                        x2="29"
+                        y2="16"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
+                      <line
+                        x1="27"
+                        y1="20"
+                        x2="29"
+                        y2="20"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                      />
                     </svg>
                   </div>
                   <h3 className="font-serif text-2xl tracking-tight">
@@ -251,7 +301,8 @@ export default function Home() {
                 </div>
                 <p className="text-base leading-relaxed text-white/60">
                   Set DPI from 72 to 600 with a built-in size calculator. Know
-                  exactly how your QR will print. Professional output every time.
+                  exactly how your QR will print. Professional output every
+                  time.
                 </p>
               </li>
 
@@ -265,15 +316,50 @@ export default function Home() {
                     >
                       {/* QR code with gradient/style variation */}
                       <defs>
-                        <linearGradient id="qr-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-                          <stop offset="0%" stopColor="currentColor" stopOpacity="1" />
-                          <stop offset="100%" stopColor="currentColor" stopOpacity="0.4" />
+                        <linearGradient
+                          id="qr-gradient"
+                          x1="0%"
+                          y1="0%"
+                          x2="100%"
+                          y2="100%"
+                        >
+                          <stop
+                            offset="0%"
+                            stopColor="currentColor"
+                            stopOpacity="1"
+                          />
+                          <stop
+                            offset="100%"
+                            stopColor="currentColor"
+                            stopOpacity="0.4"
+                          />
                         </linearGradient>
                       </defs>
                       {/* Corner blocks with rounded edges */}
-                      <rect x="2" y="2" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
-                      <rect x="2" y="25" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
-                      <rect x="25" y="2" width="5" height="5" rx="1" fill="url(#qr-gradient)" />
+                      <rect
+                        x="2"
+                        y="2"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
+                      <rect
+                        x="2"
+                        y="25"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
+                      <rect
+                        x="25"
+                        y="2"
+                        width="5"
+                        height="5"
+                        rx="1"
+                        fill="url(#qr-gradient)"
+                      />
                       {/* Styled data modules */}
                       <circle cx="10" cy="3" r="1" opacity="0.8" />
                       <circle cx="14" cy="3" r="1" opacity="0.6" />
@@ -341,9 +427,7 @@ export default function Home() {
             <div className="font-serif text-2xl italic text-fg">
               The QR <span className="text-accent">Spot</span>
             </div>
-            <p className="mt-1 text-xs text-muted">
-              Pay once, own forever.
-            </p>
+            <p className="mt-1 text-xs text-muted">Pay once, own forever.</p>
           </div>
 
           {/* Links */}
@@ -351,7 +435,7 @@ export default function Home() {
             <ul className="flex flex-wrap justify-center gap-8 md:gap-10">
               <li>
                 <a
-                  href="#"
+                  href="/privacy"
                   className="text-sm text-muted transition-colors hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent"
                 >
                   Privacy Policy
@@ -359,7 +443,7 @@ export default function Home() {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="/terms"
                   className="text-sm text-muted transition-colors hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent"
                 >
                   Terms of Service
@@ -367,7 +451,7 @@ export default function Home() {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="/faq"
                   className="text-sm text-muted transition-colors hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent"
                 >
                   Support
@@ -375,7 +459,9 @@ export default function Home() {
               </li>
               <li>
                 <a
-                  href="#"
+                  href="https://x.com/theqrspot"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="text-sm text-muted transition-colors hover:text-fg focus:outline-none focus:ring-2 focus:ring-accent"
                   aria-label="Follow us on Twitter"
                 >

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,274 @@
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-[#fffef9] text-[#1a1a1a]">
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <h1 className="mb-8 font-serif text-5xl italic">Terms of Service</h1>
+        <p className="mb-12 text-sm text-gray-600">
+          Last Updated: March 23, 2026
+        </p>
+
+        <div className="prose prose-lg max-w-none">
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Agreement to Terms</h2>
+            <p>
+              By accessing or using The QR Spot (
+              <a
+                href="https://theqrspot.com"
+                className="text-[#ff4d00] hover:underline"
+              >
+                https://theqrspot.com
+              </a>
+              ), operated by Helios Innovations, you agree to be bound by these
+              Terms of Service. If you do not agree to these terms, please do
+              not use our service.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Description of Service</h2>
+            <p>
+              The QR Spot is a QR code generator service that allows you to:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Generate QR codes for free with no limits</li>
+              <li>Save QR codes to your dashboard with a free account</li>
+              <li>Edit and manage your saved QR codes</li>
+              <li>View scan analytics for your QR codes</li>
+              <li>Create bulk QR codes for business use</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">User Accounts</h2>
+            <h3 className="mb-3 mt-6 text-2xl font-semibold">
+              Account Creation
+            </h3>
+            <p>
+              To save QR codes to your dashboard, you must create an account by
+              providing a valid email address. We use magic link authentication
+              — no passwords are required.
+            </p>
+
+            <h3 className="mb-3 mt-6 text-2xl font-semibold">
+              Account Responsibilities
+            </h3>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>You are responsible for maintaining access to your email</li>
+              <li>You must not share account access with others</li>
+              <li>
+                You must notify us immediately of any unauthorized account use
+              </li>
+              <li>You must be at least 13 years old to create an account</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Acceptable Use</h2>
+            <p>When using The QR Spot, you agree NOT to:</p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                Create QR codes that link to illegal, harmful, or malicious
+                content
+              </li>
+              <li>
+                Use the service for phishing, fraud, or deceptive practices
+              </li>
+              <li>
+                Create QR codes that distribute malware, viruses, or harmful
+                software
+              </li>
+              <li>Violate any applicable laws or regulations</li>
+              <li>Infringe on the intellectual property rights of others</li>
+              <li>
+                Attempt to disrupt, hack, or compromise our service or
+                infrastructure
+              </li>
+              <li>
+                Use automated tools to generate excessive numbers of QR codes
+              </li>
+              <li>
+                Impersonate others or create QR codes on behalf of others
+                without permission
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Intellectual Property</h2>
+            <h3 className="mb-3 mt-6 text-2xl font-semibold">Our Content</h3>
+            <p>
+              The QR Spot website, branding, design, and underlying technology
+              are owned by Helios Innovations and protected by copyright and
+              other intellectual property laws.
+            </p>
+
+            <h3 className="mb-3 mt-6 text-2xl font-semibold">Your Content</h3>
+            <p>
+              You retain ownership of the URLs and content you link to via your
+              QR codes. By using our service, you grant us a limited license to
+              process and store this information solely to provide the service.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Service Availability</h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                We strive to maintain 99.9% uptime but do not guarantee
+                uninterrupted service
+              </li>
+              <li>
+                We may perform maintenance that temporarily affects availability
+              </li>
+              <li>
+                We are not liable for any losses due to service interruptions
+              </li>
+              <li>
+                QR codes you generate are permanent — they do not expire or stop
+                working
+              </li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Payment Terms</h2>
+            <p>The QR Spot offers both free and paid features:</p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong>Free tier:</strong> Generate unlimited QR codes, save to
+                dashboard
+              </li>
+              <li>
+                <strong>Paid features:</strong> One-time payment for editing and
+                advanced features
+              </li>
+              <li>All payments are processed securely via Stripe</li>
+              <li>Refunds are handled on a case-by-case basis</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">
+              Disclaimer of Warranties
+            </h2>
+            <p>
+              The QR Spot is provided "as is" and "as available" without
+              warranties of any kind, either express or implied, including but
+              not limited to:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Merchantability</li>
+              <li>Fitness for a particular purpose</li>
+              <li>Non-infringement</li>
+              <li>Accuracy or reliability of any content</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">
+              Limitation of Liability
+            </h2>
+            <p>
+              To the maximum extent permitted by law, Helios Innovations shall
+              not be liable for any indirect, incidental, special,
+              consequential, or punitive damages, including but not limited to:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Loss of profits or revenue</li>
+              <li>Loss of data</li>
+              <li>Loss of business opportunities</li>
+              <li>Service interruptions</li>
+            </ul>
+            <p className="mt-4">
+              Our total liability for any claim shall not exceed the amount you
+              paid us in the past 12 months, or $100, whichever is greater.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Indemnification</h2>
+            <p>
+              You agree to indemnify and hold harmless Helios Innovations from
+              any claims, damages, or expenses (including legal fees) arising
+              from:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Your use of the service</li>
+              <li>Your violation of these terms</li>
+              <li>Your violation of any third-party rights</li>
+              <li>Content you link to via QR codes</li>
+            </ul>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Termination</h2>
+            <p>
+              We reserve the right to suspend or terminate your account at any
+              time for:
+            </p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>Violation of these Terms of Service</li>
+              <li>Illegal or fraudulent activity</li>
+              <li>Creating harmful or malicious QR codes</li>
+              <li>Abuse of the service</li>
+            </ul>
+            <p className="mt-4">
+              Upon termination, your right to use the service ceases
+              immediately. QR codes you have already generated will continue to
+              function.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Governing Law</h2>
+            <p>
+              These Terms shall be governed by and construed in accordance with
+              the laws of the United States. Any disputes arising from these
+              terms shall be resolved in the courts of the United States.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Changes to Terms</h2>
+            <p>
+              We may update these Terms of Service from time to time. Changes
+              will be posted on this page with an updated "Last Updated" date.
+              Continued use of the service after changes constitutes acceptance
+              of the new terms.
+            </p>
+          </section>
+
+          <section className="mb-12">
+            <h2 className="mb-4 font-serif text-3xl">Contact Us</h2>
+            <p>For questions about these Terms of Service:</p>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                Email:{" "}
+                <a
+                  href="mailto:info@heliosinnovations.org"
+                  className="text-[#ff4d00] hover:underline"
+                >
+                  info@heliosinnovations.org
+                </a>
+              </li>
+              <li>
+                Website:{" "}
+                <a
+                  href="https://theqrspot.com"
+                  className="text-[#ff4d00] hover:underline"
+                >
+                  https://theqrspot.com
+                </a>
+              </li>
+            </ul>
+          </section>
+
+          <p className="mt-12 border-t pt-6 text-sm italic text-gray-600">
+            By using The QR Spot, you acknowledge that you have read,
+            understood, and agree to be bound by these Terms of Service.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- Create `/terms` page with comprehensive Terms of Service content
- Fix footer links that were pointing to `#` instead of actual routes
- Privacy Policy link now points to `/privacy`
- Terms of Service link now points to `/terms`
- Support link now points to `/faq`
- Twitter link now points to `https://x.com/theqrspot`

## Test plan
- [ ] Verify `/privacy` page loads with full content
- [ ] Verify `/terms` page loads with full Terms of Service content
- [ ] Verify footer links on homepage navigate correctly
- [ ] Test all links in footer work properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #98