### PR TITLE
feat(#95): Add breadcrumb navigation to bulk creation page

### DIFF
--- a/src/app/bulk/page.tsx
+++ b/src/app/bulk/page.tsx
@@ -57,6 +57,24 @@ export default function BulkPage() {
       </header>
 
       <main id="main-content" className="min-h-screen bg-bg pt-[72px]">
+        {/* Breadcrumb */}
+        <div className="mx-auto max-w-7xl px-6 lg:px-12">
+          <nav
+            className="flex items-center gap-2 pb-4 pt-6 text-sm"
+            aria-label="Breadcrumb"
+          >
+            <Link
+              href="/"
+              className="text-[var(--muted)] no-underline transition-colors hover:text-[var(--accent)]"
+            >
+              Home
+            </Link>
+            <span className="text-[var(--muted)]" aria-hidden="true">
+              /
+            </span>
+            <span className="font-medium text-[var(--fg)]">Bulk Creation</span>
+          </nav>
+        </div>
         <BulkQRCreator />
       </main>
     </>


### PR DESCRIPTION
## Summary
- Adds breadcrumb navigation (Home > Bulk Creation) to the /bulk page
- Matches existing breadcrumb pattern from dashboard detail pages
- Uses consistent styling with project CSS variables
- Includes proper ARIA labels for accessibility
- Responsive design that works on all screen sizes

## Test plan
- [ ] Visit /bulk page and verify breadcrumb appears
- [ ] Click "Home" link and verify it navigates to /
- [ ] Test on mobile viewport to verify responsive layout
- [ ] Verify styling matches other breadcrumbs in the project

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)