### PR TITLE
fix(#94): Fix QR code not regenerating for email and other non-URL content types

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -810,9 +810,11 @@ function GeneratorContent() {
       !processedUrl.startsWith("http://") &&
       !processedUrl.startsWith("https://") &&
       !processedUrl.startsWith("WIFI:") &&
+      !processedUrl.startsWith("wifi:") &&
       !processedUrl.startsWith("BEGIN:") &&
       !processedUrl.startsWith("mailto:") &&
       !processedUrl.startsWith("sms:") &&
+      !processedUrl.startsWith("tel:") &&
       !processedUrl.startsWith("geo:")
     ) {
       processedUrl = "https://" + processedUrl;
@@ -1364,6 +1366,20 @@ showpage
     generateQR();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Auto-regenerate QR when URL/content input changes (debounced)
+  useEffect(() => {
+    // Skip if URL is empty or invalid
+    if (!url.trim() || !urlValid) return;
+
+    // Debounce the regeneration to avoid excessive calls while typing
+    const timer = setTimeout(() => {
+      generateQR();
+    }, 300);
+
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, urlValid]);
 
   // Keyboard shortcuts
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed the advanced generator (/generator) not updating QR codes when the content input changes
- Added support for `tel:` protocol for phone numbers
- Added support for lowercase `wifi:` protocol

## Root Cause
The QR code only regenerated when style options (colors, patterns, resolution) changed. When a user typed in a new email address or any other content, the QR stayed showing the old value because:
1. The auto-regenerate `useEffect` only watched for style changes
2. It used `generatedUrl` (the cached processed URL) instead of the current `url` state

## Fix
Added a new `useEffect` hook that:
- Watches for changes to `url` and `urlValid` state
- Triggers `generateQR()` with a 300ms debounce to avoid excessive regeneration while typing
- Only regenerates when the URL is non-empty and valid

## Test plan
- [ ] Enter `mailto:info@heliosinnovations.org` - QR should update in real-time
- [ ] Enter `tel:+1234567890` - QR should encode phone number
- [ ] Enter `sms:+1234567890` - QR should encode SMS link  
- [ ] Enter `WIFI:T:WPA;S:NetworkName;P:Password;;` - QR should encode WiFi config
- [ ] Enter `BEGIN:VCARD\nVERSION:3.0\nFN:Name\nEND:VCARD` - QR should encode vCard
- [ ] Enter any URL - QR should update as user types
- [ ] Scan generated QR codes to verify correct content

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)