### PR TITLE
fix(#89): Add italic styling to logo on dashboard page

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -47,9 +47,9 @@ export default function DashboardLayout({
         <div className="mx-auto flex max-w-[1200px] items-center justify-between px-6 py-4">
           <Link
             href="/"
-            className="font-serif text-2xl text-[var(--fg)] no-underline"
+            className="font-serif text-2xl italic text-[var(--fg)] no-underline"
           >
-            The<span className="text-[var(--accent)]">QR</span>Spot
+            The QR <span className="text-[var(--accent)]">Spot</span>
           </Link>
 
           <nav className="hidden items-center gap-8 md:flex">


### PR DESCRIPTION
## Summary
- Fixed the logo on the dashboard page to use italic styling
- Updated the logo format to match other pages: "The QR Spot" with proper spacing
- Logo now consistently styled across all pages: homepage, generator, bulk, dashboard

## Test plan
- [ ] Visit / (homepage) - logo should be italic
- [ ] Visit /generator - logo should be italic
- [ ] Visit /bulk - logo should be italic
- [ ] Visit /dashboard (requires login) - logo should now be italic
- [ ] Check on mobile and desktop viewports

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)