### PR TITLE
feat: no-login QR downloads + enhanced auth flow

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { createClient } from '@/lib/supabase/client';
-import { trackEvent } from '@/lib/analytics';
+import { useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import { trackEvent } from "@/lib/analytics";
 
 interface AuthModalProps {
   isOpen: boolean;
@@ -10,10 +10,72 @@ interface AuthModalProps {
 }
 
 export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
-  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [oauthLoading, setOauthLoading] = useState<"google" | "github" | null>(
+    null
+  );
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
   const supabase = createClient();
+
+  const handleGoogleSignIn = async () => {
+    setOauthLoading("google");
+    setMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+
+      if (error) throw error;
+      trackEvent.identifyUser("oauth_google", { method: "google" });
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to sign in with Google";
+      setMessage({
+        type: "error",
+        text: errorMessage,
+      });
+      trackEvent.error("auth_google_failed", errorMessage);
+      setOauthLoading(null);
+    }
+  };
+
+  const handleGitHubSignIn = async () => {
+    setOauthLoading("github");
+    setMessage(null);
+
+    try {
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: `${window.location.origin}/auth/callback`,
+        },
+      });
+
+      if (error) throw error;
+      trackEvent.identifyUser("oauth_github", { method: "github" });
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : "Failed to sign in with GitHub";
+      setMessage({
+        type: "error",
+        text: errorMessage,
+      });
+      trackEvent.error("auth_github_failed", errorMessage);
+      setOauthLoading(null);
+    }
+  };
 
   const handleMagicLink = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -31,17 +93,19 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
       if (error) throw error;
 
       setMessage({
-        type: 'success',
-        text: 'Check your email for the magic link!',
+        type: "success",
+        text: "Check your email for the magic link!",
       });
-      trackEvent.identifyUser(email, { method: 'magic_link' });
-      setEmail('');
-    } catch (error: any) {
+      trackEvent.identifyUser(email, { method: "magic_link" });
+      setEmail("");
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Failed to send magic link";
       setMessage({
-        type: 'error',
-        text: error.message || 'Failed to send magic link',
+        type: "error",
+        text: errorMessage,
       });
-      trackEvent.error('auth_magic_link_failed', error.message);
+      trackEvent.error("auth_magic_link_failed", errorMessage);
     } finally {
       setLoading(false);
     }
@@ -51,7 +115,7 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
 
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-fg/50 backdrop-blur-sm"
+      className="bg-fg/50 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm"
       onClick={onClose}
     >
       <div
@@ -78,14 +142,74 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
         {/* Header */}
         <div className="mb-6">
           <h2 className="font-serif text-3xl italic text-fg">
-            Sign in to The QR Spot
+            Sign in to save your QR codes
           </h2>
           <p className="mt-2 text-sm text-muted">
-            Enter your email to receive a magic link
+            One-click sign in to save and manage your QR codes
           </p>
         </div>
 
-        {/* Form */}
+        {/* OAuth Buttons */}
+        <div className="mb-6 space-y-3">
+          <button
+            onClick={handleGoogleSignIn}
+            disabled={oauthLoading !== null}
+            className="flex w-full items-center justify-center gap-3 rounded border border-border bg-white px-4 py-3 text-[15px] font-medium text-fg transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {oauthLoading === "google" ? (
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-muted border-t-accent" />
+            ) : (
+              <svg className="h-5 w-5" viewBox="0 0 24 24">
+                <path
+                  fill="#4285F4"
+                  d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                />
+              </svg>
+            )}
+            Continue with Google
+          </button>
+
+          <button
+            onClick={handleGitHubSignIn}
+            disabled={oauthLoading !== null}
+            className="hover:bg-fg/90 flex w-full items-center justify-center gap-3 rounded border border-fg bg-fg px-4 py-3 text-[15px] font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {oauthLoading === "github" ? (
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+            ) : (
+              <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+            )}
+            Continue with GitHub
+          </button>
+        </div>
+
+        {/* Divider */}
+        <div className="relative mb-6">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-border" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-bg px-3 text-xs text-muted">
+              or continue with email
+            </span>
+          </div>
+        </div>
+
+        {/* Magic Link Form */}
         <form onSubmit={handleMagicLink} className="space-y-4">
           <div>
             <label
@@ -101,7 +225,7 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               required
-              disabled={loading}
+              disabled={loading || oauthLoading !== null}
               className="w-full border-b-2 border-border bg-transparent py-3 text-lg text-fg outline-none transition-colors placeholder:text-muted focus:border-accent disabled:opacity-50"
             />
           </div>
@@ -109,9 +233,9 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
           {message && (
             <div
               className={`rounded border p-3 text-sm ${
-                message.type === 'success'
-                  ? 'border-green-600 bg-green-50 text-green-800'
-                  : 'border-red-600 bg-red-50 text-red-800'
+                message.type === "success"
+                  ? "border-green-600 bg-green-50 text-green-800"
+                  : "border-red-600 bg-red-50 text-red-800"
               }`}
             >
               {message.text}
@@ -120,25 +244,27 @@ export default function AuthModal({ isOpen, onClose }: AuthModalProps) {
 
           <button
             type="submit"
-            disabled={loading || message?.type === 'success'}
-            className={`w-full px-6 py-4 text-[15px] font-semibold transition-colors disabled:cursor-not-allowed ${
-              message?.type === 'success'
-                ? 'bg-green-600 text-white'
-                : 'bg-accent text-white hover:bg-fg disabled:opacity-50'
+            disabled={
+              loading || oauthLoading !== null || message?.type === "success"
+            }
+            className={`w-full px-6 py-3 text-[15px] font-semibold transition-colors disabled:cursor-not-allowed ${
+              message?.type === "success"
+                ? "bg-green-600 text-white"
+                : "bg-accent text-white hover:bg-fg disabled:opacity-50"
             }`}
           >
             {loading
-              ? 'Sending...'
-              : message?.type === 'success'
-                ? 'Magic Link Sent ✓'
-                : 'Send Magic Link'}
+              ? "Sending..."
+              : message?.type === "success"
+                ? "Magic Link Sent ✓"
+                : "Send Magic Link"}
           </button>
         </form>
 
         {/* Footer */}
         <div className="mt-6 text-center text-xs text-muted">
           <p>
-            By signing in, you agree to our{' '}
+            By signing in, you agree to our{" "}
             <a href="/privacy" className="underline hover:text-fg">
               Privacy Policy
             </a>

--- a/src/components/SimpleQRGenerator.tsx
+++ b/src/components/SimpleQRGenerator.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { trackEvent } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
 import AuthModal from "@/components/AuthModal";
+import { User } from "@supabase/supabase-js";
 
 // Generate a random 8-character alphanumeric code
 function generateShortCode(): string {
@@ -70,6 +71,26 @@ export default function SimpleQRGenerator() {
     message: string;
   } | null>(null);
   const [savedQrId, setSavedQrId] = useState<string | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [userLoading, setUserLoading] = useState(true);
+
+  // Check user authentication status
+  useEffect(() => {
+    const supabase = createClient();
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+      setUserLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
 
   // Generate QR code when URL changes (with debounce)
   const generateQR = useCallback(async (inputUrl: string) => {
@@ -139,13 +160,63 @@ export default function SimpleQRGenerator() {
 
     const link = document.createElement("a");
     link.href = qrDataUrl;
-    link.download = "qr-code.png";
+    link.download = `qr-code-${Date.now()}.png`;
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
 
     trackEvent.qrDownloaded("png", "simple");
   }, [qrDataUrl]);
+
+  const downloadSVG = useCallback(async () => {
+    if (!url.trim()) return;
+
+    // Process URL - only add https:// if it's not a special protocol
+    let processedUrl = url.trim();
+    const specialProtocols = [
+      "http://",
+      "https://",
+      "mailto:",
+      "tel:",
+      "sms:",
+      "WIFI:",
+      "wifi:",
+      "BEGIN:",
+      "geo:",
+    ];
+    const hasProtocol = specialProtocols.some((protocol) =>
+      processedUrl.startsWith(protocol)
+    );
+    if (!hasProtocol) {
+      processedUrl = "https://" + processedUrl;
+    }
+
+    try {
+      const svgString = await QRCode.toString(processedUrl, {
+        type: "svg",
+        margin: 2,
+        color: {
+          dark: "#1a1a1a",
+          light: "#ffffff",
+        },
+        errorCorrectionLevel: "M",
+      });
+
+      const blob = new Blob([svgString], { type: "image/svg+xml" });
+      const downloadUrl = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = downloadUrl;
+      link.download = `qr-code-${Date.now()}.svg`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(downloadUrl);
+
+      trackEvent.qrDownloaded("svg", "simple");
+    } catch {
+      // Silent fail for invalid URLs
+    }
+  }, [url]);
 
   // Save QR code to database
   const saveQRCode = useCallback(async () => {
@@ -369,6 +440,7 @@ export default function SimpleQRGenerator() {
       {/* Actions Section */}
       {qrDataUrl && (
         <div className="flex flex-col gap-3 sm:gap-4">
+          {/* Download buttons - always available, no login required */}
           <div className="flex items-center gap-2 sm:gap-4">
             <button
               onClick={downloadPNG}
@@ -385,43 +457,83 @@ export default function SimpleQRGenerator() {
               </svg>
               Download PNG
             </button>
-            {savedQrId ? (
-              <Link
-                href="/dashboard"
-                className="flex flex-1 items-center justify-center gap-1.5 border-2 border-green-600 bg-green-50 px-3 py-2.5 text-sm font-semibold text-green-700 transition-colors hover:bg-green-100 sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
+            <button
+              onClick={downloadSVG}
+              className="flex flex-1 items-center justify-center gap-1.5 border-2 border-fg bg-transparent px-3 py-2.5 text-sm font-semibold text-fg transition-colors hover:bg-fg hover:text-bg sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
               >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
-                >
-                  <path d="M20 6L9 17l-5-5" />
-                </svg>
-                View in Dashboard
-              </Link>
-            ) : (
-              <button
-                onClick={saveQRCode}
-                disabled={isSaving}
-                className="flex flex-1 items-center justify-center gap-1.5 border-2 border-fg bg-transparent px-3 py-2.5 text-sm font-semibold text-fg transition-colors hover:bg-fg hover:text-bg disabled:cursor-not-allowed disabled:opacity-50 sm:gap-2 sm:px-6 sm:py-4 sm:text-[15px]"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
-                >
-                  <path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z" />
-                  <polyline points="17 21 17 13 7 13 7 21" />
-                  <polyline points="7 3 7 8 15 8" />
-                </svg>
-                {isSaving ? "Saving..." : "Save QR Code"}
-              </button>
-            )}
+                <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4M7 10l5 5 5-5M12 15V3" />
+              </svg>
+              Download SVG
+            </button>
           </div>
+
+          {/* Save to dashboard button for logged-in users */}
+          {!userLoading && user && (
+            <>
+              {savedQrId ? (
+                <Link
+                  href="/dashboard"
+                  className="flex items-center justify-center gap-2 border-2 border-green-600 bg-green-50 px-4 py-3 text-sm font-semibold text-green-700 transition-colors hover:bg-green-100 sm:py-4 sm:text-[15px]"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
+                  >
+                    <path d="M20 6L9 17l-5-5" />
+                  </svg>
+                  View in Dashboard
+                </Link>
+              ) : (
+                <button
+                  onClick={saveQRCode}
+                  disabled={isSaving}
+                  className="flex items-center justify-center gap-2 bg-accent px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-fg disabled:cursor-not-allowed disabled:opacity-50 sm:py-4 sm:text-[15px]"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    className="h-4 w-4 sm:h-[18px] sm:w-[18px]"
+                  >
+                    <path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z" />
+                    <polyline points="17 21 17 13 7 13 7 21" />
+                    <polyline points="7 3 7 8 15 8" />
+                  </svg>
+                  {isSaving ? "Saving..." : "💾 Save to Dashboard"}
+                </button>
+              )}
+            </>
+          )}
+
+          {/* Subtle prompt for non-logged-in users */}
+          {!userLoading && !user && !savedQrId && (
+            <div className="border-accent/30 rounded-lg border bg-accent-light p-4">
+              <p className="mb-3 text-sm text-fg">
+                💾 Want to save and manage your QR codes?
+              </p>
+              <button
+                onClick={() => setShowAuthModal(true)}
+                className="w-full bg-accent px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-fg sm:py-3"
+              >
+                Create Free Account
+              </button>
+              <p className="mt-2 text-center text-xs text-muted">
+                Save unlimited QR codes • Re-download anytime • Organize with
+                folders
+              </p>
+            </div>
+          )}
 
           {/* Save status message */}
           {saveStatus && !savedQrId && (


### PR DESCRIPTION
## Summary

- Users can now download PNG and SVG QR codes **without login**
- Added Google and GitHub OAuth buttons for one-click sign in
- Subtle "Create Free Account" prompt shown to non-logged-in users
- "Save to Dashboard" button shown for logged-in users
- Auto-save QR code after successful sign in

## Changes

### SimpleQRGenerator.tsx
- Added user authentication state tracking
- Added SVG download button (no login required)
- Differentiated UI for logged-in vs non-logged-in users
- Added subtle signup prompt with value proposition

### AuthModal.tsx
- Added Google OAuth sign-in button
- Added GitHub OAuth sign-in button
- Updated header messaging to focus on saving QR codes
- Added "or continue with email" divider

## Test plan

- [ ] Generate QR without login → Download PNG → Verify works
- [ ] Generate QR without login → Download SVG → Verify works
- [ ] Click "Create Free Account" → Auth modal opens
- [ ] Sign in with Google → Redirects to dashboard
- [ ] Sign in with GitHub → Redirects to dashboard
- [ ] Return to homepage (logged in) → Generate QR → Click "Save" → Verify saved
- [ ] Check dashboard → Verify QR appears in saved list
- [ ] Test on mobile (touch targets, modal UX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)