### PR TITLE
fix(#130): Fix 50 QR code limit not working for CSV uploads

### DIFF
--- a/src/components/BulkQRCreator.tsx
+++ b/src/components/BulkQRCreator.tsx
@@ -345,6 +345,7 @@ export default function BulkQRCreator() {
 
   const parseCSV = useCallback((file: File) => {
     Papa.parse(file, {
+      skipEmptyLines: true,
       complete: (results) => {
         const data = results.data as string[][];
         if (data.length < 2) {
@@ -438,6 +439,7 @@ export default function BulkQRCreator() {
     try {
       const results = Papa.parse<string[]>(text, {
         delimiter: delimiter,
+        skipEmptyLines: true,
       });
 
       if (results.errors && results.errors.length > 0) {


### PR DESCRIPTION
## Summary

- Fixed bug where uploading exactly 50 QR codes in CSV would keep the Continue button disabled
- Root cause: CSV files with trailing newlines were being parsed with an extra empty row
- Added `skipEmptyLines: true` to Papa.parse configuration

## Test plan
- [ ] Upload CSV with 49 QR codes (should work)
- [ ] Upload CSV with 50 QR codes (should work now)
- [ ] Upload CSV with 51 QR codes (should show limit error)
- [ ] Paste data with trailing newlines (should work correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)