### PR TITLE
fix(#134): Fix remaining payment text in footer and metadata

### DIFF
--- a/src/app/generator/layout.tsx
+++ b/src/app/generator/layout.tsx
@@ -5,7 +5,7 @@ import Footer from "@/components/Footer";
 export const metadata: Metadata = {
   title: "Advanced QR Code Generator | The QR Spot - Create Custom QR Codes",
   description:
-    "Create stunning, customized QR codes with our advanced generator. Full control over colors, patterns, logos, labels, and export formats. Free to generate, pay once to edit.",
+    "Create stunning, customized QR codes with our advanced generator. Full control over colors, patterns, logos, labels, and export formats. Completely free to use.",
   keywords: [
     "QR code generator",
     "custom QR code",

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
           >
             The QR <span className="text-accent">Spot</span>
           </Link>
-          <p className="mt-1 text-xs text-muted">Pay once, own forever.</p>
+          <p className="mt-1 text-xs text-muted">Free forever.</p>
         </div>
 
         {/* Links */}


### PR DESCRIPTION
## Summary
- Updated footer text from "Pay once, own forever." to "Free forever."
- Updated generator metadata description from "Free to generate, pay once to edit." to "Completely free to use."

Fixes remaining payment references found by Nitty during QA of PR #135.

## Test plan
- [x] Build passes locally
- [x] TypeScript compiles without errors
- [ ] Visual verification of footer text change
- [ ] SEO meta tag verification in page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)