### PR TITLE
feat(#138): Add QR type selection UI - Static vs Dynamic

### DIFF
--- a/src/app/generator/page.tsx
+++ b/src/app/generator/page.tsx
@@ -17,8 +17,10 @@ import {
 } from "@/components/ContentTypeForms";
 import { createClient } from "@/lib/supabase/client";
 import AuthModal from "@/components/AuthModal";
+import QRTypeSelector from "@/components/QRTypeSelector";
 import type { User } from "@supabase/supabase-js";
 
+type QRType = "static" | "dynamic";
 type TabType = "content" | "labels" | "colors" | "style" | "export";
 type ToastType = { message: string; type: "success" | "error"; id: number };
 type ErrorLevelType = "L" | "M" | "Q" | "H";
@@ -673,9 +675,13 @@ function GeneratorContent() {
   // Get URL from query params
   const searchParams = useSearchParams();
   const urlParam = searchParams.get("url");
+  const qrTypeParam = searchParams.get("qr_type") as QRType | null;
 
   // Form state
   const [url, setUrl] = useState(urlParam || "");
+  const [qrType, setQrType] = useState<QRType | undefined>(
+    qrTypeParam || undefined
+  );
   const [urlValid, setUrlValid] = useState(false);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
   const [isGenerating, setIsGenerating] = useState(false);
@@ -922,7 +928,8 @@ function GeneratorContent() {
           title,
           short_code: shortCode,
           destination_url: generatedUrl,
-          is_editable: false,
+          is_editable: qrType === "dynamic",
+          qr_type: qrType || "static",
           scan_count: 0,
           qr_data: qrCustomization,
         })
@@ -950,6 +957,7 @@ function GeneratorContent() {
   }, [
     qrDataUrl,
     generatedUrl,
+    qrType,
     fgColor,
     bgColor,
     pattern,
@@ -2090,6 +2098,26 @@ showpage
                             below
                           </p>
                         </div>
+
+                        {/* QR Type Selector */}
+                        {urlValid && (
+                          <div className="mb-5">
+                            <label className="mb-2 flex items-center gap-1.5 text-xs font-semibold text-[var(--pro-fg)]">
+                              QR Type
+                            </label>
+                            <QRTypeSelector
+                              selectedType={qrType}
+                              onSelect={setQrType}
+                            />
+                            {qrType && (
+                              <p className="mt-2 text-xs text-[var(--pro-muted)]">
+                                {qrType === "static"
+                                  ? "Static QR codes point directly to your URL and cannot be changed after printing."
+                                  : "Dynamic QR codes use a redirect server. Edit the destination anytime for $1.99 (one-time fee)."}
+                              </p>
+                            )}
+                          </div>
+                        )}
 
                         {/* Quick Actions */}
                         <div className="flex flex-wrap gap-1.5">

--- a/src/components/QRTypeSelector.tsx
+++ b/src/components/QRTypeSelector.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+interface QRTypeSelectorProps {
+  onSelect: (type: "static" | "dynamic") => void;
+  selectedType?: "static" | "dynamic";
+}
+
+export default function QRTypeSelector({
+  onSelect,
+  selectedType,
+}: QRTypeSelectorProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {/* Static QR Card */}
+      <button
+        onClick={() => onSelect("static")}
+        className={`rounded-lg border-2 p-6 text-left transition ${
+          selectedType === "static"
+            ? "border-accent bg-accent-light"
+            : "border-border hover:border-accent"
+        }`}
+      >
+        <div className="mb-3 text-2xl">📄</div>
+        <h3 className="mb-2 font-serif text-xl font-semibold">
+          Static QR - Free
+        </h3>
+        <p className="mb-4 text-sm text-muted">
+          Points directly to your URL. Cannot be changed after printing.
+        </p>
+
+        <div className="mb-3 text-sm font-medium">Best for:</div>
+        <ul className="space-y-1 text-sm text-muted">
+          <li>• Business cards</li>
+          <li>• Flyers & posters</li>
+          <li>• Temporary displays</li>
+        </ul>
+      </button>
+
+      {/* Dynamic QR Card */}
+      <button
+        onClick={() => onSelect("dynamic")}
+        className={`rounded-lg border-2 p-6 text-left transition ${
+          selectedType === "dynamic"
+            ? "border-accent bg-accent-light"
+            : "border-border hover:border-accent"
+        }`}
+      >
+        <div className="mb-3 text-2xl">🔄</div>
+        <h3 className="mb-2 font-serif text-xl font-semibold">Dynamic QR</h3>
+        <p className="mb-2 text-sm font-semibold text-accent">
+          $1.99 one-time at first edit
+        </p>
+        <p className="mb-4 text-sm text-muted">
+          Change destination anytime without reprinting.
+        </p>
+
+        <div className="mb-3 text-sm font-medium">Best for:</div>
+        <ul className="space-y-1 text-sm text-muted">
+          <li>• Billboards</li>
+          <li>• Product packaging</li>
+          <li>• Permanent installations</li>
+        </ul>
+
+        <p className="mt-4 text-xs italic text-muted">
+          $1.99 vs $500+ to reprint & reinstall
+        </p>
+      </button>
+    </div>
+  );
+}

--- a/src/components/SimpleQRGenerator.tsx
+++ b/src/components/SimpleQRGenerator.tsx
@@ -6,7 +6,10 @@ import Link from "next/link";
 import { trackEvent } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
 import AuthModal from "@/components/AuthModal";
+import QRTypeSelector from "@/components/QRTypeSelector";
 import { User } from "@supabase/supabase-js";
+
+type QRType = "static" | "dynamic";
 
 // Generate a random 8-character alphanumeric code
 function generateShortCode(): string {
@@ -73,6 +76,8 @@ export default function SimpleQRGenerator() {
   const [savedQrId, setSavedQrId] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [userLoading, setUserLoading] = useState(true);
+  const [qrType, setQrType] = useState<QRType | undefined>(undefined);
+  const [showTypeSelector, setShowTypeSelector] = useState(false);
 
   // Check user authentication status
   useEffect(() => {
@@ -148,6 +153,13 @@ export default function SimpleQRGenerator() {
     }, 300);
     return () => clearTimeout(timer);
   }, [url, generateQR]);
+
+  // Reset QR type and saved status when URL changes
+  useEffect(() => {
+    setQrType(undefined);
+    setSavedQrId(null);
+    setSaveStatus(null);
+  }, [url]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
@@ -273,7 +285,8 @@ export default function SimpleQRGenerator() {
           title,
           short_code: shortCode,
           destination_url: processedUrl,
-          is_editable: false,
+          is_editable: qrType === "dynamic",
+          qr_type: qrType || "static",
           scan_count: 0,
         })
         .select("id")
@@ -312,7 +325,7 @@ export default function SimpleQRGenerator() {
       message: "Failed to generate unique code. Please try again.",
     });
     setIsSaving(false);
-  }, [qrDataUrl, url]);
+  }, [qrDataUrl, url, qrType]);
 
   // Listen for auth state changes to auto-save after login
   useEffect(() => {
@@ -331,9 +344,13 @@ export default function SimpleQRGenerator() {
     return () => subscription.unsubscribe();
   }, [showAuthModal, saveQRCode]);
 
-  const moreOptionsUrl = url.trim()
-    ? `/generator?url=${encodeURIComponent(url.trim())}`
-    : "/generator";
+  const moreOptionsUrl = (() => {
+    const params = new URLSearchParams();
+    if (url.trim()) params.set("url", url.trim());
+    if (qrType) params.set("qr_type", qrType);
+    const queryString = params.toString();
+    return queryString ? `/generator?${queryString}` : "/generator";
+  })();
 
   return (
     <div className="bg-surface p-8" role="form" aria-label="QR Code Generator">
@@ -437,8 +454,46 @@ export default function SimpleQRGenerator() {
         </p>
       )}
 
-      {/* Actions Section */}
-      {qrDataUrl && (
+      {/* QR Type Selector - Show after QR is generated */}
+      {qrDataUrl && !qrType && (
+        <div className="mb-6">
+          <p className="mb-4 text-center text-sm font-medium text-fg">
+            Choose your QR type:
+          </p>
+          <QRTypeSelector
+            selectedType={qrType}
+            onSelect={(type) => {
+              setQrType(type);
+            }}
+          />
+        </div>
+      )}
+
+      {/* Selected type indicator */}
+      {qrDataUrl && qrType && (
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-lg">{qrType === "static" ? "📄" : "🔄"}</span>
+            <span className="text-sm font-medium">
+              {qrType === "static" ? "Static QR" : "Dynamic QR"}
+            </span>
+            {qrType === "dynamic" && (
+              <span className="rounded bg-accent-light px-2 py-0.5 text-xs font-semibold text-accent">
+                $1.99 at first edit
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => setQrType(undefined)}
+            className="text-xs text-muted transition-colors hover:text-accent"
+          >
+            Change
+          </button>
+        </div>
+      )}
+
+      {/* Actions Section - Only show after type is selected */}
+      {qrDataUrl && qrType && (
         <div className="flex flex-col gap-3 sm:gap-4">
           {/* Download buttons - always available, no login required */}
           <div className="flex items-center gap-2 sm:gap-4">


### PR DESCRIPTION
## Summary
- Add new `QRTypeSelector` component for choosing between Static and Dynamic QR codes
- Integrate type selection into SimpleQRGenerator (homepage) - shown after URL is entered, before download/save
- Integrate type selection into Generator page (advanced) - shown after URL is validated
- Store selected `qr_type` in database when saving QR codes
- Dynamic QR codes are marked as `is_editable=true`

## Changes
- **New file:** `src/components/QRTypeSelector.tsx` - Two-card selector UI matching OneQR design system
- **Modified:** `src/components/SimpleQRGenerator.tsx` - Added type selection step
- **Modified:** `src/app/generator/page.tsx` - Added type selection in content tab

## Test plan
- [ ] Enter URL on homepage, verify QR type selection appears
- [ ] Select Static QR, verify download buttons appear
- [ ] Select Dynamic QR, verify "$1.99 at first edit" badge shows
- [ ] Change selection using "Change" button
- [ ] Save QR code and verify `qr_type` is stored in database
- [ ] Navigate to advanced generator with type param preserved
- [ ] Mobile responsive - cards stack vertically on small screens

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)